### PR TITLE
fix: version indicator

### DIFF
--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -1,7 +1,10 @@
 local addonName, ns = ...
 
 ns.addonName = addonName
-ns.version = "1.0.0"
+
+-- Read version from TOC file (compatible with all WoW versions)
+local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata
+ns.version = GetAddOnMetadata(addonName, "Version") or "1.0.0"
 
 ns.Modules = {}
 

--- a/GudaBags.toc
+++ b/GudaBags.toc
@@ -2,7 +2,7 @@
 ## Title: GudaBags
 ## Notes: Clean, unified bag management for Classic expansions
 ## Author: Vati
-## Version: 1.0.5
+## Version: 1.0.6
 ## SavedVariables: GudaBags_DB
 ## SavedVariablesPerCharacter: GudaBags_CharDB
 ## IconTexture: Interface\AddOns\GudaBags\Assets\bags.png


### PR DESCRIPTION
This pull request updates the addon's versioning system to ensure the version number is dynamically read from the TOC file, which improves compatibility and maintainability. It also increments the version in the TOC file to reflect the new release.

Version management improvements:

* Updated `Core/Init.lua` to read the version number dynamically from the TOC file using `GetAddOnMetadata`, ensuring compatibility with all WoW versions and reducing the risk of version mismatches.

Release update:

* Bumped the version number in `GudaBags.toc` from 1.0.5 to 1.0.6 to indicate a new release.