### PR TITLE
feat: flyout features

### DIFF
--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -55,6 +55,7 @@ local function InitializeCharDB()
     GudaBags_CharDB.pinnedSlots = GudaBags_CharDB.pinnedSlots or {}
     GudaBags_CharDB.lockedItems = GudaBags_CharDB.lockedItems or {}
     GudaBags_CharDB.setProtectionExceptions = GudaBags_CharDB.setProtectionExceptions or {}
+    GudaBags_CharDB.markedJunk = GudaBags_CharDB.markedJunk or {}
 
     for key, default in pairs(Constants.DEFAULTS) do
         if GudaBags_CharDB.settings[key] == nil then
@@ -261,6 +262,32 @@ function Database:ToggleItemLock(itemID)
         GudaBags_CharDB.lockedItems[itemID] = true
         return true
     end
+end
+
+-------------------------------------------------
+-- Marked Junk (per-character, itemID-based)
+-------------------------------------------------
+
+function Database:IsItemMarkedJunk(itemID)
+    if not itemID or not GudaBags_CharDB or not GudaBags_CharDB.markedJunk then return false end
+    return GudaBags_CharDB.markedJunk[itemID] or false
+end
+
+function Database:ToggleItemMarkedJunk(itemID)
+    if not itemID or not GudaBags_CharDB then return false end
+    GudaBags_CharDB.markedJunk = GudaBags_CharDB.markedJunk or {}
+    if GudaBags_CharDB.markedJunk[itemID] then
+        GudaBags_CharDB.markedJunk[itemID] = nil
+        return false
+    else
+        GudaBags_CharDB.markedJunk[itemID] = true
+        return true
+    end
+end
+
+function Database:GetMarkedJunkSet()
+    if not GudaBags_CharDB or not GudaBags_CharDB.markedJunk then return {} end
+    return GudaBags_CharDB.markedJunk
 end
 
 -------------------------------------------------

--- a/Core/Rules/TooltipRule.lua
+++ b/Core/Rules/TooltipRule.lua
@@ -77,6 +77,16 @@ RuleEngine:RegisterEvaluator("isJunk", function(ruleValue, itemData, context)
         return false == ruleValue
     end
 
+    -- User-marked junk overrides quality, profession-tool protection, and
+    -- special-properties checks. Mark state is per-character (CharDB), so
+    -- only honored when not viewing another character's bags.
+    if not context.isOtherChar and itemData.itemID then
+        local Database = ns:GetModule("Database")
+        if Database and Database:IsItemMarkedJunk(itemData.itemID) then
+            return true == ruleValue
+        end
+    end
+
     -- For other characters, only check quality
     if context.isOtherChar then
         return (itemData.quality == 0) == ruleValue

--- a/GudaBags.toc
+++ b/GudaBags.toc
@@ -2,7 +2,7 @@
 ## Title: GudaBags
 ## Notes: Clean, unified bag management for all WoW versions
 ## Author: Vati
-## Version: 1.8.1
+## Version: 1.8.2
 ## SavedVariables: GudaBags_DB
 ## SavedVariablesPerCharacter: GudaBags_CharDB
 ## IconTexture: Interface\AddOns\GudaBags\Assets\bags.png

--- a/GudaBags.toc
+++ b/GudaBags.toc
@@ -71,6 +71,7 @@ UI\Controls\Select.lua
 # UI Components (Reusable)
 UI\Components\DragDropManager.lua
 UI\Components\CategoryDropIndicator.lua
+UI\Components\DragFlyoutBar.lua
 
 # UI Layout
 UI\Layout\VerticalStack.lua

--- a/Locales.lua
+++ b/Locales.lua
@@ -552,6 +552,17 @@ L["PROFILE_RESET_DEFAULTS"] = "Reset Defaults"
 L["PROFILE_RESET_CONFIRM"] = "Reset all settings to defaults? This cannot be undone."
 L["PROFILE_RESET_MSG"] = "Settings reset to defaults"
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Track this item"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Untrack this item"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Lock this item"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Unlock this item"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Pin this slot"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Unpin this slot"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Mark as junk"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Unmark as junk"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Will be auto-sold at vendor"
+
 -------------------------------------------------
 -- Other Languages (placeholders for translators)
 -------------------------------------------------
@@ -933,6 +944,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[Épinglez un emplacement pour le protéger du tri.
 Les emplacements épinglés sont |cff00ccccignorés|r lors du tri.
 L'épingle reste sur l'emplacement, pas sur l'objet.
 Une icône d'épingle apparaît en bas à gauche.]]
+
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Suivre cet objet"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Ne plus suivre cet objet"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Verrouiller cet objet"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Déverrouiller cet objet"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Épingler cet emplacement"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Désépingler cet emplacement"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Marquer comme camelote"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Démarquer la camelote"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Sera vendu automatiquement chez le marchand"
 
 -- German
 local L = Locales.deDE
@@ -1368,6 +1390,17 @@ Die Nadel bleibt am Platz, nicht am Gegenstand.
 Ein Nadel-Symbol erscheint unten links.]]
 --@localization(locale="deDE", format="lua_additive_table")@
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Diesen Gegenstand verfolgen"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Verfolgung beenden"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Gegenstand sperren"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Gegenstand entsperren"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Platz anheften"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Platz lösen"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Als Müll markieren"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Müll-Markierung entfernen"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Wird beim Händler automatisch verkauft"
+
 -- Russian
 local L = Locales.ruRU
 L["ADDON_LOADED"] = "v%s загружен. Введите /guda для открытия."
@@ -1743,6 +1776,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[Закрепите ячейку сумки, что�
 Закреплённые ячейки |cff00ccccпропускаются|r при сортировке.
 Закрепление остаётся на ячейке, а не на предмете.
 Значок булавки появляется слева внизу.]]
+
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Отслеживать предмет"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Прекратить отслеживание"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Заблокировать предмет"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Разблокировать предмет"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Закрепить ячейку"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Открепить ячейку"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Отметить как хлам"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Снять метку хлама"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Будет автоматически продано у торговца"
 
 -- Brazilian Portuguese
 local L = Locales.ptBR
@@ -2120,6 +2164,17 @@ Slots fixados são |cff00ccccignorados|r durante a ordenação.
 A fixação fica no slot, não no item.
 Um ícone de pino aparece no canto inferior esquerdo.]]
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Rastrear este item"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Parar de rastrear este item"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Bloquear este item"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Desbloquear este item"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Fixar este slot"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Desafixar este slot"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Marcar como lixo"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Desmarcar como lixo"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Será vendido automaticamente no vendedor"
+
 -- Spanish (Spain)
 local L = Locales.esES
 L["ADDON_LOADED"] = "v%s cargado. Escribe /guda para abrir."
@@ -2495,6 +2550,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[Fija una ranura de bolsa para protegerla al ordenar
 Las ranuras fijadas se |cff00ccccignoran|r al ordenar.
 La fijación queda en la ranura, no en el objeto.
 Un icono de pin aparece en la esquina inferior izquierda.]]
+
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Seguir este objeto"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Dejar de seguir este objeto"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Bloquear este objeto"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Desbloquear este objeto"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Fijar esta ranura"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Soltar esta ranura"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Marcar como basura"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Quitar marca de basura"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Se venderá automáticamente al vendedor"
 
 -- Spanish (Mexico) - Uses esES translations
 local L = Locales.esMX
@@ -2880,6 +2946,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[釘選背包欄位以保護其不被排序。
 釘選綁定在欄位上，不跟隨物品。
 釘選圖示顯示在左下角。]]
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "追蹤此物品"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "取消追蹤此物品"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "鎖定此物品"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "解鎖此物品"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "釘選此欄位"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "取消釘選此欄位"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "標記為垃圾"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "取消標記為垃圾"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "將自動售予商人"
+
 -- Simplified Chinese
 local L = Locales.zhCN
 L["ADDON_LOADED"] = "v%s 已加载。输入 /guda 打开。"
@@ -3257,6 +3334,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[钉选背包栏位以保护其不被排序。
 钉选绑定在栏位上，不跟随物品。
 钉选图标显示在左下角。]]
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "追踪此物品"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "取消追踪此物品"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "锁定此物品"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "解锁此物品"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "钉选此栏位"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "取消钉选此栏位"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "标记为垃圾"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "取消标记为垃圾"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "将自动售给商人"
+
 -- Korean
 local L = Locales.koKR
 L["SETTINGS_GENERAL_DESCRIPTION"] = "GudaBags는 가벼운 가방 애드온입니다. 기능과 팁은 |cffffd100가이드|r 탭을 확인하세요."
@@ -3570,6 +3658,17 @@ L["GUIDE_PIN_SLOT_DESC"] = [[가방 슬롯을 고정하여 정렬에서 보호�
 고정은 슬롯에 유지되며, 아이템을 따라가지 않습니다.
 핀 아이콘이 왼쪽 하단에 표시됩니다.]]
 
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "이 아이템 추적"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "추적 해제"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "아이템 잠금"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "아이템 잠금 해제"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "이 슬롯 고정"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "고정 해제"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "쓰레기로 표시"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "쓰레기 표시 해제"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "상인에게 자동 판매됩니다"
+
 -- Italian
 local L = Locales.itIT
 L["SETTINGS_GENERAL_DESCRIPTION"] = "GudaBags è un addon per borse leggero. Controlla la scheda |cffffd100Guida|r per funzionalità e suggerimenti."
@@ -3882,3 +3981,14 @@ L["GUIDE_PIN_SLOT_DESC"] = [[Fissa uno slot borsa per proteggerlo dall'ordinamen
 Gli slot fissati vengono |cff00ccccignora|r durante l'ordinamento.
 La fissatura resta sullo slot, non sull'oggetto.
 Un'icona puntina appare in basso a sinistra.]]
+
+-- Drag-Flyout Drop Targets
+L["TOOLTIP_FLYOUT_TRACK_OFF"] = "Traccia questo oggetto"
+L["TOOLTIP_FLYOUT_TRACK_ON"] = "Smetti di tracciare"
+L["TOOLTIP_FLYOUT_LOCK_OFF"] = "Blocca oggetto"
+L["TOOLTIP_FLYOUT_LOCK_ON"] = "Sblocca oggetto"
+L["TOOLTIP_FLYOUT_PIN_OFF"] = "Fissa questo slot"
+L["TOOLTIP_FLYOUT_PIN_ON"] = "Sblocca questo slot"
+L["TOOLTIP_FLYOUT_JUNK_OFF"] = "Segna come spazzatura"
+L["TOOLTIP_FLYOUT_JUNK_ON"] = "Rimuovi marchio spazzatura"
+L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"] = "Sarà venduto automaticamente al mercante"

--- a/Sorting/SortEngine.lua
+++ b/Sorting/SortEngine.lua
@@ -453,6 +453,9 @@ end
 
 -- Pinned slots set, loaded once per sort pass
 local currentPinnedSlots = {}
+-- User-marked junk set, loaded once per sort pass. Kept outside sortKeyCache
+-- so toggling a mark at runtime takes effect without invalidating the cache.
+local currentMarkedJunk = {}
 
 local function SnapshotSlots(bagIDs)
     local slotMap = {}  -- key: bagID*1000+slot → entry (or nil for empty)
@@ -460,6 +463,7 @@ local function SnapshotSlots(bagIDs)
     local sequence = 0
     local whiteItemsJunk = Database:GetSetting("whiteItemsJunk") or false
     currentPinnedSlots = Database:GetPinnedSlotSet()
+    currentMarkedJunk = Database:GetMarkedJunkSet()
 
     for _, bagID in ipairs(bagIDs) do
         local numSlots = C_Container_GetContainerNumSlots(bagID)
@@ -545,6 +549,11 @@ local function SnapshotSlots(bagIDs)
                 sequence = sequence + 1
                 local key = bagID * 1000 + slot
                 local isPinned = currentPinnedSlots[key] or false
+                -- User-mark override: applied here (not in sk cache) so toggles
+                -- take effect on the next sort without cache invalidation.
+                local userMarkedJunk = currentMarkedJunk[itemID] or false
+                local effectiveIsJunk = sk.isJunk or userMarkedJunk
+                local effectiveSortedClassID = userMarkedJunk and 100 or sk.sortedClassID
                 local entry = {
                     bagID = bagID,
                     slot = slot,
@@ -555,11 +564,11 @@ local function SnapshotSlots(bagIDs)
                     isPinned = isPinned,
                     -- Inline sort keys (no separate table per item)
                     priority = sk.priority,
-                    sortedClassID = sk.sortedClassID,
+                    sortedClassID = effectiveSortedClassID,
                     sortedSubClassID = sk.sortedSubClassID,
                     sortedEquipSlot = sk.sortedEquipSlot,
                     isEquippable = sk.isEquippable,
-                    isJunk = sk.isJunk,
+                    isJunk = effectiveIsJunk,
                     invertedQuality = sk.invertedQuality,
                     invertedItemLevel = sk.invertedItemLevel,
                     invertedItemID = sk.invertedItemID,

--- a/UI/BagFrame.lua
+++ b/UI/BagFrame.lua
@@ -143,6 +143,50 @@ function BagFrame:HandleContainerDrop()
     ClearCursor()
 end
 
+-- Locate the cursor item's source slot by scanning for the locked slot.
+-- Returns bagID, slot, source ("bag"|"bank") or nil if not found.
+function BagFrame:GetCursorBagSlot()
+    -- Player bags
+    for bagID = 0, NUM_BAG_SLOTS do
+        local numSlots = C_Container.GetContainerNumSlots(bagID)
+        for slot = 1, numSlots do
+            local itemInfo = C_Container.GetContainerItemInfo(bagID, slot)
+            if itemInfo and itemInfo.isLocked then
+                return bagID, slot, "bag"
+            end
+        end
+    end
+
+    -- Bank slots
+    local bankBags = {}
+    if Constants.CHARACTER_BANK_TAB_IDS and #Constants.CHARACTER_BANK_TAB_IDS > 0 then
+        for _, tabID in ipairs(Constants.CHARACTER_BANK_TAB_IDS) do
+            table.insert(bankBags, tabID)
+        end
+    end
+    if Constants.WARBAND_BANK_TAB_IDS and #Constants.WARBAND_BANK_TAB_IDS > 0 then
+        for _, tabID in ipairs(Constants.WARBAND_BANK_TAB_IDS) do
+            table.insert(bankBags, tabID)
+        end
+    end
+    if #bankBags == 0 and Constants.BANK_BAG_IDS and #Constants.BANK_BAG_IDS > 0 then
+        for _, bagID in ipairs(Constants.BANK_BAG_IDS) do
+            table.insert(bankBags, bagID)
+        end
+    end
+    for _, bagID in ipairs(bankBags) do
+        local numSlots = C_Container.GetContainerNumSlots(bagID)
+        if numSlots and numSlots > 0 then
+            for slot = 1, numSlots do
+                local itemInfo = C_Container.GetContainerItemInfo(bagID, slot)
+                if itemInfo and itemInfo.isLocked then
+                    return bagID, slot, "bank"
+                end
+            end
+        end
+    end
+end
+
 -- Separate container for secure item buttons - NOT a child of the bag frame
 -- This prevents the bag frame from becoming protected
 local secureButtonContainer = nil
@@ -1060,6 +1104,10 @@ function BagFrame:Hide()
         if dragCheckTicker then
             dragCheckTicker:Cancel()
             dragCheckTicker = nil
+        end
+        local DragFlyoutBar = ns:GetModule("DragFlyoutBar")
+        if DragFlyoutBar then
+            DragFlyoutBar:OnDragEnd()
         end
     end
 end
@@ -1986,44 +2034,61 @@ Events:Register("ITEM_LOCK_CHANGED", function(event, bagID, slotID)
         ItemButton:UpdateLockForItem(bagID, slotID)
     end
 
-    -- Detect drag start for showing empty category drop targets
+    -- Detect drag start for showing the flyout drop bar (all views) and the
+    -- empty-category drop targets (category view only).
     -- Deferred by one frame to distinguish equip operations (cursor clears within
     -- the same frame) from actual user drags (cursor persists across frames).
     -- Without this, right-click equip triggers false drag detection because the
     -- WoW client briefly puts the item on the cursor during the internal swap,
     -- causing two full Refresh() calls that destroy ghost slots.
     if frame and frame:IsShown() and not viewingCharacter and not isDraggingItem then
-        local viewType = Database:GetSetting("bagViewType") or "single"
-        if viewType == "category" then
-            C_Timer.After(0, function()
-                if isDraggingItem then return end
-                if not frame or not frame:IsShown() then return end
-                if viewingCharacter then return end
-                -- Ignore lock events while the sort engine is moving items
-                local SortEngine = ns:GetModule("SortEngine")
-                if SortEngine and (SortEngine:IsSorting() or SortEngine:IsRestacking()) then
-                    return
+        C_Timer.After(0, function()
+            if isDraggingItem then return end
+            if not frame or not frame:IsShown() then return end
+            if viewingCharacter then return end
+            -- Ignore lock events while the sort engine is moving items
+            local SortEngine = ns:GetModule("SortEngine")
+            if SortEngine and (SortEngine:IsSorting() or SortEngine:IsRestacking()) then
+                return
+            end
+            local cursorType, cursorItemID = GetCursorInfo()
+            if cursorType == "item" then
+                isDraggingItem = true
+
+                local sourceBag, sourceSlot, source = BagFrame:GetCursorBagSlot()
+
+                local DragFlyoutBar = ns:GetModule("DragFlyoutBar")
+                if DragFlyoutBar then
+                    DragFlyoutBar:OnDragStart(cursorItemID, sourceBag, sourceSlot, source)
                 end
-                local cursorType = GetCursorInfo()
-                if cursorType == "item" then
-                    isDraggingItem = true
+
+                local viewType = Database:GetSetting("bagViewType") or "single"
+                if viewType == "category" then
                     BagFrame:Refresh()
-                    -- Poll for cursor clear (item dropped/cancelled)
-                    dragCheckTicker = C_Timer.NewTicker(0.1, function()
-                        if not CursorHasItem() then
-                            isDraggingItem = false
-                            if dragCheckTicker then
-                                dragCheckTicker:Cancel()
-                                dragCheckTicker = nil
-                            end
-                            if frame and frame:IsShown() then
+                end
+
+                -- Poll for cursor clear (item dropped/cancelled)
+                dragCheckTicker = C_Timer.NewTicker(0.1, function()
+                    if not CursorHasItem() then
+                        isDraggingItem = false
+                        if dragCheckTicker then
+                            dragCheckTicker:Cancel()
+                            dragCheckTicker = nil
+                        end
+                        local DragFlyoutBar = ns:GetModule("DragFlyoutBar")
+                        if DragFlyoutBar then
+                            DragFlyoutBar:OnDragEnd()
+                        end
+                        if frame and frame:IsShown() then
+                            local viewType = Database:GetSetting("bagViewType") or "single"
+                            if viewType == "category" then
                                 BagFrame:Refresh()
                             end
                         end
-                    end)
-                end
-            end)
-        end
+                    end
+                end)
+            end
+        end)
     end
 end, BagFrame)
 

--- a/UI/Components/DragFlyoutBar.lua
+++ b/UI/Components/DragFlyoutBar.lua
@@ -9,8 +9,8 @@ ns:RegisterModule("DragFlyoutBar", DragFlyoutBar)
 
 local BUTTON_SIZE = 36
 local BUTTON_SPACING = 6
-local BAR_PADDING = 6
-local BAR_GAP = 4
+local BAR_PADDING = 3
+local BAR_GAP = 2
 
 local TARGETS = { "track", "lock", "pin", "junk" }
 

--- a/UI/Components/DragFlyoutBar.lua
+++ b/UI/Components/DragFlyoutBar.lua
@@ -1,0 +1,312 @@
+local addonName, ns = ...
+
+local DragFlyoutBar = {}
+ns:RegisterModule("DragFlyoutBar", DragFlyoutBar)
+
+-------------------------------------------------
+-- Layout
+-------------------------------------------------
+
+local BUTTON_SIZE = 36
+local BUTTON_SPACING = 6
+local BAR_PADDING = 6
+local BAR_GAP = 4
+
+local TARGETS = { "track", "lock", "pin", "junk" }
+
+local TARGET_ICONS = {
+    track = "Interface\\AddOns\\GudaBags\\Assets\\fav.png",
+    lock  = "Interface\\AddOns\\GudaBags\\Assets\\lock.png",
+    pin   = "Interface\\AddOns\\GudaBags\\Assets\\pin.png",
+    junk  = "Interface\\Buttons\\UI-GroupLoot-Coin-Up",
+}
+
+-- Per-target visual nudges (some Blizzard textures have asymmetric padding)
+local TARGET_ICON_Y_OFFSET = {
+    junk = -3,
+}
+
+-------------------------------------------------
+-- State
+-------------------------------------------------
+
+local bar = nil
+local buttons = {}
+local dropCooldown = false
+local currentItemID = nil
+local currentBagID = nil
+local currentSlot = nil
+
+-------------------------------------------------
+-- Forward declarations
+-------------------------------------------------
+
+local UpdateButtonState
+
+-------------------------------------------------
+-- Tooltip helpers (state-aware, reads cursor item state)
+-------------------------------------------------
+
+local function GetTooltipText(targetType)
+    local L = ns.L
+
+    if targetType == "track" then
+        local TrackedBar = ns:GetModule("TrackedBar")
+        local isOn = TrackedBar and currentItemID and TrackedBar:IsTracked(currentItemID)
+        return isOn and L["TOOLTIP_FLYOUT_TRACK_ON"] or L["TOOLTIP_FLYOUT_TRACK_OFF"]
+    elseif targetType == "lock" then
+        local Database = ns:GetModule("Database")
+        local isOn = Database and currentItemID and Database:IsItemLocked(currentItemID)
+        return isOn and L["TOOLTIP_FLYOUT_LOCK_ON"] or L["TOOLTIP_FLYOUT_LOCK_OFF"]
+    elseif targetType == "pin" then
+        local Database = ns:GetModule("Database")
+        local isOn = Database and currentBagID and currentSlot and Database:IsPinnedSlot(currentBagID, currentSlot)
+        return isOn and L["TOOLTIP_FLYOUT_PIN_ON"] or L["TOOLTIP_FLYOUT_PIN_OFF"]
+    elseif targetType == "junk" then
+        local Database = ns:GetModule("Database")
+        local isOn = Database and currentItemID and Database:IsItemMarkedJunk(currentItemID)
+        return isOn and L["TOOLTIP_FLYOUT_JUNK_ON"] or L["TOOLTIP_FLYOUT_JUNK_OFF"]
+    end
+end
+
+local function ShowButtonTooltip(button, targetType)
+    local text = GetTooltipText(targetType)
+    if not text then return end
+
+    GameTooltip:SetOwner(button, "ANCHOR_TOP")
+    GameTooltip:SetText(text, 1, 1, 1)
+
+    if targetType == "junk" then
+        local Database = ns:GetModule("Database")
+        if Database and Database:GetSetting("autoVendorJunk") then
+            GameTooltip:AddLine(ns.L["TOOLTIP_FLYOUT_JUNK_AUTOVENDOR"], 1, 0.82, 0)
+        end
+    end
+
+    GameTooltip:Show()
+end
+
+-------------------------------------------------
+-- Bar / button creation
+-------------------------------------------------
+
+local function CreateButton(targetType, index)
+    local btn = CreateFrame("Button", nil, bar)
+    btn:SetSize(BUTTON_SIZE, BUTTON_SIZE)
+
+    local x = BAR_PADDING + (index - 1) * (BUTTON_SIZE + BUTTON_SPACING)
+    btn:SetPoint("TOPLEFT", bar, "TOPLEFT", x, -BAR_PADDING)
+
+    -- Slot background (matches CategoryDropIndicator style)
+    local slotBg = btn:CreateTexture(nil, "BACKGROUND")
+    slotBg:SetPoint("TOPLEFT", btn, "TOPLEFT", -9, 9)
+    slotBg:SetPoint("BOTTOMRIGHT", btn, "BOTTOMRIGHT", 9, -9)
+    slotBg:SetTexture("Interface\\Buttons\\UI-EmptySlot")
+    slotBg:SetVertexColor(0.6, 0.6, 0.6, 0.9)
+    btn.slotBg = slotBg
+
+    -- Icon
+    local icon = btn:CreateTexture(nil, "ARTWORK")
+    icon:SetPoint("CENTER", btn, "CENTER", 0, TARGET_ICON_Y_OFFSET[targetType] or 0)
+    icon:SetSize(BUTTON_SIZE * 0.7, BUTTON_SIZE * 0.7)
+    icon:SetTexture(TARGET_ICONS[targetType])
+    btn.icon = icon
+
+    -- Highlight overlay
+    local highlight = btn:CreateTexture(nil, "HIGHLIGHT")
+    highlight:SetAllPoints(icon)
+    highlight:SetTexture("Interface\\Buttons\\ButtonHilight-Square")
+    highlight:SetBlendMode("ADD")
+
+    btn:EnableMouse(true)
+    btn:RegisterForDrag("LeftButton")
+
+    btn:SetScript("OnMouseDown", function(self, mouseButton)
+        if mouseButton == "LeftButton" then
+            pcall(function() DragFlyoutBar:HandleDrop(targetType) end)
+        end
+    end)
+
+    btn:SetScript("OnReceiveDrag", function(self)
+        pcall(function() DragFlyoutBar:HandleDrop(targetType) end)
+    end)
+
+    btn:SetScript("OnEnter", function(self)
+        ShowButtonTooltip(self, targetType)
+    end)
+
+    btn:SetScript("OnLeave", function(self)
+        GameTooltip:Hide()
+    end)
+
+    btn.targetType = targetType
+    return btn
+end
+
+local function CreateBar()
+    if bar then return bar end
+
+    local barWidth = BAR_PADDING * 2 + #TARGETS * BUTTON_SIZE + (#TARGETS - 1) * BUTTON_SPACING
+    local barHeight = BAR_PADDING * 2 + BUTTON_SIZE
+
+    bar = CreateFrame("Frame", "GudaBagsDragFlyoutBar", UIParent)
+    bar:SetSize(barWidth, barHeight)
+    bar:SetFrameStrata("FULLSCREEN_DIALOG")
+    bar:SetFrameLevel(500)
+
+    for i, targetType in ipairs(TARGETS) do
+        buttons[targetType] = CreateButton(targetType, i)
+    end
+
+    bar:Hide()
+    return bar
+end
+
+-------------------------------------------------
+-- State updates (icon tint based on current toggle state)
+-------------------------------------------------
+
+UpdateButtonState = function()
+    local Database = ns:GetModule("Database")
+    local TrackedBar = ns:GetModule("TrackedBar")
+
+    local function tint(targetType, isOn)
+        local btn = buttons[targetType]
+        if not btn then return end
+        if isOn then
+            btn.slotBg:SetVertexColor(0.4, 0.8, 0.4, 0.95)  -- green when active
+        else
+            btn.slotBg:SetVertexColor(0.6, 0.6, 0.6, 0.9)
+        end
+    end
+
+    tint("track", TrackedBar and currentItemID and TrackedBar:IsTracked(currentItemID))
+    tint("lock",  Database and currentItemID and Database:IsItemLocked(currentItemID))
+    tint("pin",   Database and currentBagID and currentSlot and Database:IsPinnedSlot(currentBagID, currentSlot))
+    tint("junk",  Database and currentItemID and Database:IsItemMarkedJunk(currentItemID))
+end
+
+-------------------------------------------------
+-- Public API
+-------------------------------------------------
+
+function DragFlyoutBar:OnDragStart(itemID, bagID, slot, source)
+    if dropCooldown then return end
+    if source ~= "bag" then return end
+    if not itemID then return end
+
+    local BagFrame = ns:GetModule("BagFrame")
+    if not BagFrame or not BagFrame:IsShown() then return end
+
+    local frame = BagFrame:GetFrame()
+    if not frame then return end
+
+    CreateBar()
+
+    currentItemID = itemID
+    currentBagID = bagID
+    currentSlot = slot
+
+    UpdateButtonState()
+
+    bar:ClearAllPoints()
+    bar:SetPoint("BOTTOMLEFT", frame, "TOPLEFT", 0, BAR_GAP)
+    bar:Show()
+end
+
+function DragFlyoutBar:OnDragEnd()
+    self:Hide(false)
+end
+
+function DragFlyoutBar:Hide(fromDrop)
+    if bar then
+        bar:Hide()
+    end
+    GameTooltip:Hide()
+
+    currentItemID = nil
+    currentBagID = nil
+    currentSlot = nil
+
+    if fromDrop then
+        dropCooldown = true
+        C_Timer.After(0.2, function()
+            dropCooldown = false
+        end)
+    end
+end
+
+function DragFlyoutBar:IsShown()
+    return bar and bar:IsShown()
+end
+
+-------------------------------------------------
+-- Drop handling
+-------------------------------------------------
+
+function DragFlyoutBar:HandleDrop(targetType)
+    if InCombatLockdown() then return end
+
+    local infoType, itemID = GetCursorInfo()
+    if infoType ~= "item" or not itemID then
+        self:Hide(true)
+        return
+    end
+
+    local BagFrame = ns:GetModule("BagFrame")
+    local Database = ns:GetModule("Database")
+
+    if targetType == "track" then
+        ClearCursor()
+        local TrackedBar = ns:GetModule("TrackedBar")
+        if TrackedBar then
+            TrackedBar:ToggleTrackItem(itemID)
+        end
+
+    elseif targetType == "lock" then
+        ClearCursor()
+        if Database then
+            Database:ToggleItemLock(itemID)
+        end
+        if BagFrame then
+            BagFrame:Refresh()
+        end
+
+    elseif targetType == "pin" then
+        local bagID, slot
+        if BagFrame and BagFrame.GetCursorBagSlot then
+            bagID, slot = BagFrame:GetCursorBagSlot()
+        end
+        bagID = bagID or currentBagID
+        slot = slot or currentSlot
+        ClearCursor()
+        if Database and bagID and slot then
+            Database:TogglePinnedSlot(bagID, slot)
+            if BagFrame and BagFrame.RefreshPinIcons then
+                BagFrame:RefreshPinIcons()
+            end
+        end
+
+    elseif targetType == "junk" then
+        ClearCursor()
+        if Database then
+            Database:ToggleItemMarkedJunk(itemID)
+        end
+        if BagFrame then
+            BagFrame:Refresh()
+        end
+    end
+
+    self:Hide(true)
+end
+
+-------------------------------------------------
+-- Combat hide
+-------------------------------------------------
+
+local Events = ns:GetModule("Events")
+Events:Register("PLAYER_REGEN_DISABLED", function()
+    if DragFlyoutBar:IsShown() then
+        DragFlyoutBar:Hide(false)
+    end
+end, DragFlyoutBar)

--- a/UI/ItemButton.lua
+++ b/UI/ItemButton.lua
@@ -357,6 +357,14 @@ local function IsJunkItem(itemData)
     -- (GetItemInfo hasn't cached yet — name defaults to "")
     if not itemData.name or itemData.name == "" then return false end
 
+    -- User-marked junk overrides quality and profession-tool protection.
+    if itemData.itemID then
+        local Database = ns:GetModule("Database")
+        if Database and Database:IsItemMarkedJunk(itemData.itemID) then
+            return true
+        end
+    end
+
     -- Profession tools are never junk
     if IsTool(itemData.name) then
         return false


### PR DESCRIPTION
This pull request introduces the ability for users to manually mark items as "junk" on a per-character basis, ensuring these items are always treated as junk (and auto-sold if desired) regardless of their quality or other automatic rules. It also adds a new drag-and-drop flyout bar UI component for quick item actions, and updates localization files with new tooltip strings for these actions in multiple languages. Additional improvements include better handling of drag-and-drop events and sorting logic to respect user-marked junk status.

**User-marked junk feature:**

* Added per-character storage and API (`markedJunk` table) in `Database.lua` for marking/unmarking items as junk, including new methods `IsItemMarkedJunk`, `ToggleItemMarkedJunk`, and `GetMarkedJunkSet`. [[1]](diffhunk://#diff-4913355c6700862978b65b281b37beda0237d485203234a119ddeb0db790b662R58) [[2]](diffhunk://#diff-4913355c6700862978b65b281b37beda0237d485203234a119ddeb0db790b662R267-R292)
* Updated the rule engine so user-marked junk status overrides other checks (quality, profession, etc.) when determining if an item is junk.
* Modified the sorting engine to apply user-marked junk status during sorting, ensuring these items are always sorted and treated as junk, without invalidating caches. [[1]](diffhunk://#diff-ef2fd715bb46ade4d72e474c4ac139902fa3668a59864649511cc8376411b165R456-R466) [[2]](diffhunk://#diff-ef2fd715bb46ade4d72e474c4ac139902fa3668a59864649511cc8376411b165R552-R556) [[3]](diffhunk://#diff-ef2fd715bb46ade4d72e474c4ac139902fa3668a59864649511cc8376411b165L558-R571)

**Drag-and-drop flyout bar and UI improvements:**

* Added `DragFlyoutBar` UI component and integrated it into the bag frame for drag-and-drop item actions, including proper drag start/end detection and cleanup. [[1]](diffhunk://#diff-797b95148353c4d3ec4a9df9b0b031dca27c86b6a68afb60ea8748fea92329f9R74) [[2]](diffhunk://#diff-44a9948b8492e098c5cc0f0ddc91ff0d49e896d688e95993da97230893d7bdf7R146-R189) [[3]](diffhunk://#diff-44a9948b8492e098c5cc0f0ddc91ff0d49e896d688e95993da97230893d7bdf7R1108-R1111) [[4]](diffhunk://#diff-44a9948b8492e098c5cc0f0ddc91ff0d49e896d688e95993da97230893d7bdf7L1989-L1997) [[5]](diffhunk://#diff-44a9948b8492e098c5cc0f0ddc91ff0d49e896d688e95993da97230893d7bdf7L2007-R2069) [[6]](diffhunk://#diff-44a9948b8492e098c5cc0f0ddc91ff0d49e896d688e95993da97230893d7bdf7R2078-R2091)

**Localization and versioning:**

* Added new tooltip strings for drag-flyout actions (track, lock, pin, junk) in all supported languages. [[1]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R555-R565) [[2]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R948-R958) [[3]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R1393-R1403) [[4]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R1780-R1790) [[5]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R2167-R2177) [[6]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R2554-R2564) [[7]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R2949-R2959) [[8]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R3337-R3347) [[9]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R3661-R3671) [[10]](diffhunk://#diff-cf1942ac078fee9bb76e66fc1f365db408cb52b9670703a3333a0cb9b94f8ef6R3984-R3994)
* Bumped addon version to 1.8.2.