### PR TITLE
feat: simple item level compatibility

### DIFF
--- a/Core/PublicAPI.lua
+++ b/Core/PublicAPI.lua
@@ -1,0 +1,39 @@
+local addonName, ns = ...
+
+-- Public namespace for third-party addon integration.
+-- The internal `ns` table stays private (per WoW addon convention); only the
+-- documented functions on _G.GudaBags.API are stable across versions.
+_G.GudaBags = _G.GudaBags or {}
+_G.GudaBags.API = _G.GudaBags.API or {}
+
+local itemButtonHooks = {}
+
+-- GudaBags.API.OnItemButtonUpdate(callback)
+--
+-- Register a callback that fires after each real-item update on a GudaBags
+-- item button. Signature: callback(button, bagID, slot)
+--
+-- Use this to decorate GudaBags' item buttons from another addon — e.g.,
+--   GudaBags.API.OnItemButtonUpdate(function(button, bag, slot)
+--       local item = Item:CreateFromBagAndSlot(bag, slot)
+--       MyAddon:DecorateButton(button, item)
+--   end)
+--
+-- Fires for bags, bank, and mail buttons (all share ItemButton:SetItem).
+-- Does NOT fire for: pseudo-items (Empty / Soul / DropTarget), read-only or
+-- cached-character views, or guild-bank items (synthetic bagID).
+function _G.GudaBags.API.OnItemButtonUpdate(callback)
+    if type(callback) ~= "function" then return end
+    table.insert(itemButtonHooks, callback)
+end
+
+-- Internal: invoked from UI/ItemButton.lua SetItem. Not part of the public API.
+-- pcall-wrapped so a buggy third-party callback can't break rendering.
+function ns:FireItemButtonUpdate(button, bagID, slot)
+    for i = 1, #itemButtonHooks do
+        local ok, err = pcall(itemButtonHooks[i], button, bagID, slot)
+        if not ok then
+            ns:Print("GudaBags.API hook error:", err)
+        end
+    end
+end

--- a/GudaBags.toc
+++ b/GudaBags.toc
@@ -2,7 +2,7 @@
 ## Title: GudaBags
 ## Notes: Clean, unified bag management for all WoW versions
 ## Author: Vati
-## Version: 1.8.6
+## Version: 1.8.7
 ## SavedVariables: GudaBags_DB
 ## SavedVariablesPerCharacter: GudaBags_CharDB
 ## IconTexture: Interface\AddOns\GudaBags\Assets\bags.png
@@ -18,6 +18,7 @@ Core\Locales.lua
 
 # Core modules (load order matters)
 Core\Init.lua
+Core\PublicAPI.lua
 Core\Expansion.lua
 Core\Constants.lua
 Core\Utils.lua

--- a/UI/ItemButton.lua
+++ b/UI/ItemButton.lua
@@ -321,7 +321,8 @@ end
 local function ApplyFontSize(button, fontSize)
     fontSize = fontSize or Database:GetSetting("iconFontSize")
     if button.Count then
-        button.Count:SetFont(Constants.FONTS.DEFAULT, fontSize, "OUTLINE")
+        -- ARIALN to stay consistent with the iLvl / SimpleItemLevel font family.
+        button.Count:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
         button.Count:ClearAllPoints()
         button.Count:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 0, 1)
         button.Count:SetJustifyH("RIGHT")
@@ -331,7 +332,8 @@ local function ApplyFontSize(button, fontSize)
         button.itemLevelText:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
     end
     if button.chargesText then
-        button.chargesText:SetFont(Constants.FONTS.DEFAULT, fontSize, "OUTLINE")
+        -- ARIALN to stay consistent with the iLvl / count / SimpleItemLevel font family.
+        button.chargesText:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
     end
 end
 
@@ -791,9 +793,10 @@ local function CreateButton(parent)
     itemLevelText:Hide()
     button.itemLevelText = itemLevelText
 
-    -- Charges text (bottom-right corner, e.g. "x5" for Wizard Oil)
+    -- Charges text (bottom-right corner, e.g. "x5" for Wizard Oil).
+    -- ARIALN to match the iLvl / count / SimpleItemLevel font family.
     local chargesText = button:CreateFontString(nil, "OVERLAY", nil)
-    chargesText:SetFont(Constants.FONTS.DEFAULT, 12, "OUTLINE")
+    chargesText:SetFont("Fonts\\ARIALN.TTF", 12, "OUTLINE")
     chargesText:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 0, 1)
     chargesText:SetJustifyH("RIGHT")
     chargesText:SetTextColor(1, 0.82, 0)
@@ -805,7 +808,7 @@ local function CreateButton(parent)
     -- sublayer 2-5 icons. OUTLINE keeps it readable when stacked on top of them.)
     -- Color is set per-item in SetItem() based on item quality.
     local boeText = button:CreateFontString(nil, "OVERLAY", nil, 6)
-    boeText:SetFont(Constants.FONTS.DEFAULT, 10, "OUTLINE")
+    boeText:SetFont("Fonts\\ARIALN.TTF", 10, "OUTLINE")
     boeText:SetPoint("BOTTOMLEFT", button, "BOTTOMLEFT", 1, 1)
     boeText:SetJustifyH("LEFT")
     boeText:SetText("BoE")

--- a/UI/ItemButton.lua
+++ b/UI/ItemButton.lua
@@ -303,6 +303,7 @@ local function ResetButton(pool, button)
     if button.itemLevelText then button.itemLevelText:Hide() end
     if button.chargesText then button.chargesText:Hide() end
     if button.boeText then button.boeText:Hide() end
+    if button.upgradeArrow then button.upgradeArrow:Hide() end
     if button.questIcon then button.questIcon:Hide() end
     if button.questStarterIcon then button.questStarterIcon:Hide() end
     if button.craftingQualityIcon then button.craftingQualityIcon:Hide() end
@@ -326,7 +327,8 @@ local function ApplyFontSize(button, fontSize)
         button.Count:SetJustifyH("RIGHT")
     end
     if button.itemLevelText then
-        button.itemLevelText:SetFont(Constants.FONTS.DEFAULT, fontSize, "OUTLINE")
+        -- ARIALN to stay consistent with SimpleItemLevel's font family (see CreateButton).
+        button.itemLevelText:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
     end
     if button.chargesText then
         button.chargesText:SetFont(Constants.FONTS.DEFAULT, fontSize, "OUTLINE")
@@ -689,22 +691,36 @@ local function CreateButton(parent)
     button.craftingQualityFrame = craftingQualityFrame
     button.craftingQualityIcon = craftingQualityIcon
 
-    -- Tracked/favorite icon shadow (for darker stroke effect)
+    -- Tracked/favorite icon shadow (for darker stroke effect, drawn behind the icon)
     local trackedIconShadow = button:CreateTexture(nil, "OVERLAY", nil, 2)
     trackedIconShadow:SetSize(14, 14)
-    trackedIconShadow:SetPoint("TOPRIGHT", button, "TOPRIGHT", 0, 0)
+    trackedIconShadow:SetPoint("CENTER", button, "CENTER", 0, 0)
     trackedIconShadow:SetTexture("Interface\\AddOns\\GudaBags\\Assets\\fav.png")
     trackedIconShadow:SetVertexColor(0, 0, 0, 1)
     trackedIconShadow:Hide()
     button.trackedIconShadow = trackedIconShadow
 
-    -- Tracked/favorite icon (top right corner)
+    -- Tracked/favorite icon (center of slot, freed from top-right so the
+    -- item-level text can take that corner — leaves TOPLEFT free for SimpleItemLevel).
     local trackedIcon = button:CreateTexture(nil, "OVERLAY", nil, 3)
     trackedIcon:SetSize(12, 12)
-    trackedIcon:SetPoint("TOPRIGHT", button, "TOPRIGHT", -1, -1)
+    trackedIcon:SetPoint("CENTER", button, "CENTER", 0, 0)
     trackedIcon:SetTexture("Interface\\AddOns\\GudaBags\\Assets\\fav.png")
     trackedIcon:Hide()
     button.trackedIcon = trackedIcon
+
+    -- SimpleItemLevel upgrade arrow (top-left). Rendered by us using
+    -- SimpleItemLevel.API.ItemIsUpgrade so the feature shows on GudaBags' buttons
+    -- without waiting for SimpleItemLevel to be patched upstream. Same atlas
+    -- (poi-door-arrow-up) SimpleItemLevel uses, anchored where SimpleItemLevel
+    -- would have placed it (TOPLEFT, freed by moving our iLvl to TOPRIGHT).
+    -- Stays hidden when SimpleItemLevel is not installed (gate in SetItem).
+    local upgradeArrow = button:CreateTexture(nil, "OVERLAY", nil, 4)
+    upgradeArrow:SetSize(12, 12)
+    upgradeArrow:SetPoint("TOPLEFT", button, "TOPLEFT", 2, -2)
+    upgradeArrow:SetAtlas("poi-door-arrow-up")
+    upgradeArrow:Hide()
+    button.upgradeArrow = upgradeArrow
 
     -- Equipment set icon shadow (bottom-left corner)
     local equipSetIconShadow = button:CreateTexture(nil, "OVERLAY", nil, 2)
@@ -763,11 +779,15 @@ local function CreateButton(parent)
     button.userLockIcon = userLockIcon
     button.userLockFrame = userLockFrame
 
-    -- Item level text (top-left corner)
+    -- Item level text (top-right corner). Top-left is reserved for SimpleItemLevel
+    -- when that addon is loaded (it places its iLvl there by default).
+    -- Uses ARIALN (the font family Blizzard's NumberFontNormal / SimpleItemLevel use)
+    -- so the iLvl numbers look visually consistent with SimpleItemLevel.
+    -- Size follows the user's iconFontSize setting; OUTLINE kept for readability.
     local itemLevelText = button:CreateFontString(nil, "OVERLAY", nil)
-    itemLevelText:SetFont(Constants.FONTS.DEFAULT, 12, "OUTLINE")
-    itemLevelText:SetPoint("TOPLEFT", button, "TOPLEFT", 2, -2)
-    itemLevelText:SetJustifyH("LEFT")
+    itemLevelText:SetFont("Fonts\\ARIALN.TTF", 12, "OUTLINE")
+    itemLevelText:SetPoint("TOPRIGHT", button, "TOPRIGHT", -2, -2)
+    itemLevelText:SetJustifyH("RIGHT")
     itemLevelText:Hide()
     button.itemLevelText = itemLevelText
 
@@ -1667,6 +1687,7 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
         if button.itemLevelText then button.itemLevelText:Hide() end
         if button.chargesText then button.chargesText:Hide() end
         if button.boeText then button.boeText:Hide() end
+        if button.upgradeArrow then button.upgradeArrow:Hide() end
         if button.cooldown then CooldownFrame_Set(button.cooldown, 0, 0, false) end
 
         -- Mark this button as empty slot handler
@@ -1708,6 +1729,7 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
         if button.itemLevelText then button.itemLevelText:Hide() end
         if button.chargesText then button.chargesText:Hide() end
         if button.boeText then button.boeText:Hide() end
+        if button.upgradeArrow then button.upgradeArrow:Hide() end
         if button.cooldown then CooldownFrame_Set(button.cooldown, 0, 0, false) end
 
         -- Animated glow border
@@ -1942,11 +1964,19 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
             end
         end
 
-        -- Item level display (Weapon classID=2, Armor classID=4)
+        -- Item level display (Weapon classID=2, Armor classID=4).
+        -- Text color matches the quality border so iLvl is visually grouped with
+        -- the other quality indicators (border, BoE label) on the same icon.
         if button.itemLevelText then
             local isEquip = itemData.classID and (itemData.classID == 2 or itemData.classID == 4)
             if settings.showItemLevel and isEquip and itemData.itemLevel and itemData.itemLevel > 0 and (itemData.quality or 0) > 0 then
                 button.itemLevelText:SetText(itemData.itemLevel)
+                local c = Constants.QUALITY_COLORS[itemData.quality]
+                if c then
+                    button.itemLevelText:SetTextColor(c[1], c[2], c[3], 1)
+                else
+                    button.itemLevelText:SetTextColor(1, 1, 1, 1)
+                end
                 button.itemLevelText:Show()
             else
                 button.itemLevelText:Hide()
@@ -1995,6 +2025,23 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
                 end
             else
                 button.boeText:Hide()
+            end
+        end
+
+        -- SimpleItemLevel upgrade arrow (Retail; requires SimpleItemLevel addon).
+        -- Gated on _G.SimpleItemLevel so it's invisible without that addon installed.
+        -- Uses classID (Weapon=2, Armor=4) since itemData.itemType is localized.
+        if button.upgradeArrow then
+            local sil = _G.SimpleItemLevel
+            local isEquip = itemData.classID and (itemData.classID == 2 or itemData.classID == 4)
+            if sil and sil.API and sil.API.ItemIsUpgrade
+                and not isReadOnly
+                and itemData.link
+                and isEquip
+                and sil.API.ItemIsUpgrade(itemData.link) then
+                button.upgradeArrow:Show()
+            else
+                button.upgradeArrow:Hide()
             end
         end
 
@@ -2049,6 +2096,9 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
         if button.boeText then
             button.boeText:Hide()
         end
+        if button.upgradeArrow then
+            button.upgradeArrow:Hide()
+        end
         if button.userLockIcon then
             button.userLockIcon:Hide()
         end
@@ -2069,6 +2119,17 @@ function ItemButton:SetItem(button, itemData, size, isReadOnly)
     if GameTooltip:IsOwned(button) and not InCombatLockdown() then
         local onEnter = button:GetScript("OnEnter")
         if onEnter then onEnter(button) end
+    end
+
+    -- Fire the public hook so third-party addons (e.g. SimpleItemLevel) can
+    -- decorate this button. Only for real items in a real bag/slot — skip
+    -- pseudo-items, cached/read-only views, and guild-bank synthetic IDs.
+    if not isReadOnly
+        and itemData and itemData.bagID and itemData.slot
+        and not itemData.isGuildBank
+        and not itemData.isEmptySlots
+        and not itemData.isDropTarget then
+        ns:FireItemButtonUpdate(button, itemData.bagID, itemData.slot)
     end
 end
 
@@ -2212,6 +2273,9 @@ function ItemButton:SetEmpty(button, bagID, slot, size, isReadOnly, isGuildBank)
     end
     if button.boeText then
         button.boeText:Hide()
+    end
+    if button.upgradeArrow then
+        button.upgradeArrow:Hide()
     end
     if button.userLockIcon then
         button.userLockIcon:Hide()

--- a/UI/ItemButton.lua
+++ b/UI/ItemButton.lua
@@ -321,18 +321,15 @@ end
 local function ApplyFontSize(button, fontSize)
     fontSize = fontSize or Database:GetSetting("iconFontSize")
     if button.Count then
-        -- ARIALN to stay consistent with the iLvl / SimpleItemLevel font family.
         button.Count:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
         button.Count:ClearAllPoints()
         button.Count:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 0, 1)
         button.Count:SetJustifyH("RIGHT")
     end
     if button.itemLevelText then
-        -- ARIALN to stay consistent with SimpleItemLevel's font family (see CreateButton).
         button.itemLevelText:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
     end
     if button.chargesText then
-        -- ARIALN to stay consistent with the iLvl / count / SimpleItemLevel font family.
         button.chargesText:SetFont("Fonts\\ARIALN.TTF", fontSize, "OUTLINE")
     end
 end
@@ -783,9 +780,6 @@ local function CreateButton(parent)
 
     -- Item level text (top-right corner). Top-left is reserved for SimpleItemLevel
     -- when that addon is loaded (it places its iLvl there by default).
-    -- Uses ARIALN (the font family Blizzard's NumberFontNormal / SimpleItemLevel use)
-    -- so the iLvl numbers look visually consistent with SimpleItemLevel.
-    -- Size follows the user's iconFontSize setting; OUTLINE kept for readability.
     local itemLevelText = button:CreateFontString(nil, "OVERLAY", nil)
     itemLevelText:SetFont("Fonts\\ARIALN.TTF", 12, "OUTLINE")
     itemLevelText:SetPoint("TOPRIGHT", button, "TOPRIGHT", -2, -2)
@@ -793,8 +787,7 @@ local function CreateButton(parent)
     itemLevelText:Hide()
     button.itemLevelText = itemLevelText
 
-    -- Charges text (bottom-right corner, e.g. "x5" for Wizard Oil).
-    -- ARIALN to match the iLvl / count / SimpleItemLevel font family.
+    -- Charges text (bottom-right corner, e.g. "x5" for Wizard Oil)
     local chargesText = button:CreateFontString(nil, "OVERLAY", nil)
     chargesText:SetFont("Fonts\\ARIALN.TTF", 12, "OUTLINE")
     chargesText:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 0, 1)


### PR DESCRIPTION
This pull request introduces a new public API for third-party addon integration and enhances item button rendering, especially for compatibility with the SimpleItemLevel addon. It also improves the visual consistency and flexibility of item-level and upgrade indicators on item buttons. The changes are grouped below by theme.

**Public API for Third-Party Integration:**

* Added `Core/PublicAPI.lua` providing a stable `GudaBags.API.OnItemButtonUpdate` hook for third-party addons to decorate item buttons after each real-item update. This hook is invoked safely and only for actual items, not pseudo-items or cached views. [[1]](diffhunk://#diff-d72acae67cf19436a00851b2a13e776e12c548544c0120d95b1a55de3967e6e3R1-R39) [[2]](diffhunk://#diff-797b95148353c4d3ec4a9df9b0b031dca27c86b6a68afb60ea8748fea92329f9R21)

**SimpleItemLevel Compatibility and UI Enhancements:**

* Added an upgrade arrow (`upgradeArrow`) to item buttons, visually matching SimpleItemLevel's upgrade indicator and only shown when the SimpleItemLevel addon is present and the item is an upgrade. The arrow appears in the top-left corner, and its visibility is managed in all relevant button states. [[1]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371L692-R724) [[2]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371R1690) [[3]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371R1732) [[4]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371R2031-R2047) [[5]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371R2099-R2101) [[6]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371R2277-R2279)
* Moved the item-level text from the top-left to the top-right corner of item buttons to avoid overlap with SimpleItemLevel's indicators, and updated its font to ARIALN for consistency with Blizzard and SimpleItemLevel displays. [[1]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371L766-R790) [[2]](diffhunk://#diff-0abc570f41eb930f2b1639adee81694417b810de6ecfe578eb81c81ba7b70371L329-R331)
* Updated the item-level text color to match the item's quality border, improving visual grouping of quality indicators.

**Other UI Improvements:**

* Adjusted the position of the tracked/favorite icon and its shadow to the center of the button, freeing up the top corners for item-level and upgrade indicators.

**Version Update:**

* Bumped the addon version to 1.8.7 in `GudaBags.toc`.